### PR TITLE
detect textarea elements as interactable

### DIFF
--- a/natbot.py
+++ b/natbot.py
@@ -297,6 +297,8 @@ class Crawler:
 				return "input"
 			if node_name == "img":
 				return "img"
+			if node_name == "textarea":
+				return "textarea"
 			if (
 				node_name == "button" or has_click_handler
 			):  # found pages that needed this quirk


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/72655/270064352-b6053b83-e1f3-4d0f-8c9e-bcaaf2f73681.png)

(and hitting enter doesn't actually do anything because it's trying to type into a button)

After:
![image](https://user-images.githubusercontent.com/72655/270064644-d1c7a28a-eb22-4789-aab9-e61f3facaf2d.png)

it detects the Google search textarea and fills it out correctly